### PR TITLE
DarpanX reflectivities, split `ExperimentSetup` into multiple objects and more config 

### DIFF
--- a/src/config_default.toml
+++ b/src/config_default.toml
@@ -9,3 +9,30 @@ solarModelFile = "solar_model_tensor15.csv"
 experimentSetup = "BabyIAXO"   # [BabyIAXO, CAST]
 detectorSetup   = "InGridIAXO" # [InGrid2017, InGrid2018, InGridIAXO]
 stageSetup      = "vacuum"     # [vacuum, gas]
+
+[Magnet] # allows to adjust any property of the magnet
+useConfig = false        # sets whether to read these values here. Can be overriden here or using flag `--magnet`
+B = 2.0                  # T  magnetic field of the magnet
+radiusCB = 350.0         # mm radius of the magnet cold bore
+lengthColdbore = 11300.0 # mm length of the cold bore
+lengthB = 11000.0        # mm length of the part of cold bore w/ B field
+pGasRoom = 1.0           # bar pressure of (optional) gas in magnet at room temp.
+tGas = 100.0             # K temperature of (optional) gas in magnet
+
+[TestXraySource]
+useConfig = false # sets whether to read these values here. Can be overriden here or useng flag `--testXray`
+active = true     # whether the source is active (i.e. Sun or source?)
+energy = 1.0      # keV The energy of the X-ray source
+distance = 2000.0 # mm  Distance of the X-ray source from the readout
+radius = 350.0    # mm  Radius of the X-ray source
+offAxisUp = 0.0   # mm
+offAxisLeft = 0.0 # mm
+activity = 0.125  # GBq The activity in `GBq` of the source
+lengthCol = 0.021 # mm  Length of a collimator in front of the source
+
+[DetectorInstallation]
+useConfig = false # sets whether to read these values here. Can be overriden here or useng flag `--detectorInstall`
+distanceDetectorXRT = 1485.0   # mm
+distanceWindowFocalPlane = 0.0 # mm
+lateralShift = 0.0             # mm lateral ofset of the detector in repect to the beamline
+transversalShift = 0.0         # mm transversal ofset of the detector in repect to the beamline #0.0.mm #

--- a/src/raytracer2018.nim
+++ b/src/raytracer2018.nim
@@ -147,31 +147,30 @@ type
 ## WARNING: cannot be `const` at the moment, due to Nim compiler bug with distinct types
 defUnit(GeV⁻¹)
 let
-  RAYTRACER_DISTANCE_SUN_EARTH = 1.5e14.mm # #ok
-  radiusSun = 6.9e11.mm                    # #ok
-  numberOfPointsSun = 1_000_000            #100000 for statistics   #37734 for CAST if BabyIaxo 10 mio  #26500960 corresponding to 100_000 axions at CAST, doesnt work
+  DistanceSunEarth = 1.5e14.mm # #ok
+  RadiusSun = 6.9e11.mm                    # #ok
+  NumberOfPointsSun = 1_000_000            #100000 for statistics   #37734 for CAST if BabyIaxo 10 mio  #26500960 corresponding to 100_000 axions at CAST, doesnt work
   # 1000000 axions that reach the coldbore then are reached after an operating time of 2.789 \times 10^{-5}\,\si{\second} for CAST
 
-
-  roomTemp = 293.15.K
+  RoomTemp = 293.15.K
   mAxion = 0.0853#0.26978249412621896 #eV, corresponds to set p and T gas valus #0.4 #eV for example
   g_aγ = 2e-12.GeV⁻¹
 
 ## Chipregions#####
 
 let
-  CHIPREGIONS_CHIP_X_MIN = 0.0.mm
-  CHIPREGIONS_CHIP_X_MAX = 66.0.mm #14.0.mm
-  CHIPREGIONS_CHIP_Y_MIN = 0.0.mm
-  CHIPREGIONS_CHIP_Y_MAX = 66.0.mm #14.0.mm
-  CHIPREGIONS_CHIP_CENTER_X = CHIPREGIONS_CHIP_X_MAX / 2.0 #7.0.mm
-  CHIPREGIONS_CHIP_CENTER_Y = CHIPREGIONS_CHIP_Y_MAX / 2.0 #7.0.mm
-  CHIPREGIONS_GOLD_X_MIN = 4.5.mm
-  CHIPREGIONS_GOLD_X_MAX = 9.5.mm
-  CHIPREGIONS_GOLD_Y_MIN = 4.5.mm
-  CHIPREGIONS_GOLD_Y_MAX = 9.5.mm
-  CHIPREGIONS_SILVER_RADIUS_MAX = 4.5.mm
-  CHIPREGIONS_BRONZE_RADIUS_MAX = 5.5.mm
+  ChipXMin     = 0.0.mm
+  ChipXMax     = 66.0.mm #14.0.mm
+  ChipYMin     = 0.0.mm
+  ChipYMax     = 66.0.mm #14.0.mm
+  ChipCenterX  = ChipXMax / 2.0 #7.0.mm
+  ChipCenterY  = ChipYMax / 2.0 #7.0.mm
+  GoldXMin     = 4.5.mm
+  GoldXMax     = 9.5.mm
+  GoldYMin     = 4.5.mm
+  GoldYMax     = 9.5.mm
+  SilverRadius = 4.5.mm
+  BronzeRadius = 5.5.mm
 
 ################################
 
@@ -719,7 +718,7 @@ proc plotHeatmap(diagramtitle: string,
 
   #d.zmin = 0.0
   #d.zmax = 5e-22
-  let offset = CHIPREGIONS_CHIP_CENTER_X.float
+  let offset = ChipCenterX.float
   let
     yr = linspace(- rSigma1, rSigma1, xs.len)
     yr2 = linspace(- rSigma2, rSigma2, xs.len)
@@ -730,8 +729,8 @@ proc plotHeatmap(diagramtitle: string,
                       "photon flux" : zs,
                       "yr0": yr,
                       "yr02": yr2})
-    .mutate(f{float: "x-position [mm]" ~ `x` * CHIPREGIONS_CHIP_X_MAX.float / width.float},
-            f{float: "y-position [mm]" ~ `y` * CHIPREGIONS_CHIP_Y_MAX.float / width.float},
+    .mutate(f{float: "x-position [mm]" ~ `x` * ChipXMax.float / width.float},
+            f{float: "y-position [mm]" ~ `y` * ChipYMax.float / width.float},
             f{float: "xr" ~ sqrt(rSigma1 * rSigma1 - `yr0` * `yr0`) + offset},
             f{float: "xrneg" ~ - sqrt(rSigma1 * rSigma1 - `yr0` * `yr0`) + offset},
             f{float: "yr" ~ `yr0` + offset},
@@ -740,7 +739,7 @@ proc plotHeatmap(diagramtitle: string,
             f{float: "yr2" ~ `yr02` + offset})
   template makeMinMax(knd, ax: untyped): untyped =
     template `knd ax`(): untyped =
-      `CHIPREGIONS_GOLD ax knd` * width.float / CHIPREGIONS_CHIP_X_MAX.float
+      `Gold ax knd` * width.float / ChipXMax.float
   makeMinMax(min, X)
   makeMinMax(max, X)
   makeMinMax(min, Y)
@@ -1056,7 +1055,7 @@ proc newDetectorSetup*(setup: DetectorSetupKind): DetectorSetup =
     result.openApertureRatio = 0.838 #0.95 #
     result.windowThickness = 0.3.μm #0.1.μm #microns #options are: 0.3, 0.15 and 0.1
     result.alThickness = 0.02.μm #0.01.μm
-  result.detectorWindowAperture = CHIPREGIONS_CHIP_X_MAX
+  result.detectorWindowAperture = ChipXMax
   let (width, dist) = calcWindowVals(result.radiusWindow,
                                      result.numberOfStrips,
                                      result.openApertureRatio)
@@ -1110,7 +1109,8 @@ proc traceAxion(res: var Axion,
                ) =
   ## Get a random point in the sun, biased by the emission rate, which is higher
   ## at smalller radii, so this will give more points in the center of the sun ##
-  var pointInSun = getRandomPointFromSolarModel(centerVecs.centerSun, radiusSun, emRatesRadiusCumSum)
+  var pointInSun = getRandomPointFromSolarModel(centerVecs.centerSun, RadiusSun, emRatesRadiusCumSum)
+
   var weight = 1.0
   ## Get a random point at the end of the coldbore of the magnet to take all axions into account that make it to this point no matter where they enter the magnet ##
   var pointExitCBMagneticField = getRandomPointOnDisk(
@@ -1121,7 +1121,7 @@ proc traceAxion(res: var Axion,
 
   ## Get a random energy for the axion biased by the emission rate ##
   var energyAx = getRandomEnergyFromSolarModel(
-    pointInSun, centerVecs.centerSun, radiusSun, energies, emRateCDFs)
+    pointInSun, centerVecs.centerSun, RadiusSun, energies, emRateCDFs)
   if cfXrayTest in flags:
     pointInSun = pointXraySource
     energyAx = energyXraySource
@@ -1152,7 +1152,7 @@ proc traceAxion(res: var Axion,
     var testTime = 1_000_000 / (xraysThroughHole * 3600.0.s * 24.0)
     #echo "Days Testing ", testTime, " with a ", expSetup.activityXraySource, " source"
   #let emissionRateAx = getRandomEmissionRateFromSolarModel(
-  #  pointInSun, centerVecs.centerSun, radiusSun, emRates, emRateCDFs
+  #  pointInSun, centerVecs.centerSun, RadiusSun, emRates, emRateCDFs
   #)
   ## Throw away all the axions, that don't make it through the piping system and therefore exit the system at some point ##
 
@@ -1510,7 +1510,7 @@ proc traceAxion(res: var Axion,
     transmissionMagnet = cos(ya) * probConversionMagnet
   of skGas:
     let
-      pGas = expSetup.pGasRoom / roomTemp * expSetup.tGas
+      pGas = expSetup.pGasRoom / RoomTemp * expSetup.tGas
       ## TODO: use `unchained` in `axionMass` and avoid manual float conversions / use `to`
       effPhotonMass = effPhotonMass2(
         pGas.float, pathCB.to(m).float,
@@ -1532,7 +1532,7 @@ proc traceAxion(res: var Axion,
         distancePipe.float,
         pGas.float,
         expSetup.tGas.float,
-        roomTemp.float) #room temperature in K
+        RoomTemp.float) #room temperature in K
     #echo "axion mass in [eV] ", mAxion, " effective photon mass in [eV] ", effPhotonMass
     transmissionMagnet = cos(ya) * probConversionMagnetGas * absorbtionXrays # for setup with gas
 
@@ -1579,7 +1579,7 @@ proc traceAxion(res: var Axion,
       return
 
   else:
-    if abs(pointDetectorWindow[0].mm) > CHIPREGIONS_CHIP_CENTER_X or abs(pointDetectorWindow[1].mm) > CHIPREGIONS_CHIP_CENTER_Y:
+    if abs(pointDetectorWindow[0].mm) > ChipCenterX or abs(pointDetectorWindow[1].mm) > ChipCenterY:
       return
 
   var pointDetectorWindowTurned = vec3(0.0)
@@ -1639,8 +1639,8 @@ proc traceAxion(res: var Axion,
   ###detector COS has (0/0) at the bottom left corner of the chip
   pointRadialComponent = sqrt(pointDetectorWindow[0]*pointDetectorWindow[0]+pointDetectorWindow[1]*pointDetectorWindow[1])
   res.pointdataR = pointRadialComponent
-  pointDetectorWindow[0] = - pointDetectorWindow[0] + CHIPREGIONS_CHIP_CENTER_X.float # for the view from the detector to the sun
-  pointDetectorWindow[1] = pointDetectorWindow[1] + CHIPREGIONS_CHIP_CENTER_Y.float
+  pointDetectorWindow[0] = - pointDetectorWindow[0] + ChipCenterX.float # for the view from the detector to the sun
+  pointDetectorWindow[1] = pointDetectorWindow[1] + ChipCenterY.float
 
   if cfXrayTest notin flags:
     case expSetup.kind
@@ -1657,21 +1657,21 @@ proc traceAxion(res: var Axion,
 
   ## TODO: the following are not used for anything!
   let
-    gold = ( (pointDetectorWindow[0] >= CHIPREGIONS_GOLD_X_MIN.float) and (
-        pointDetectorWindow[0] <= CHIPREGIONS_GOLD_X_MAX.float) and (
-        pointDetectorWindow[1] >= CHIPREGIONS_GOLD_Y_MIN.float) and (
-        pointDetectorWindow[1] <= CHIPREGIONS_GOLD_Y_MAX.float))
-    r_xy = sqrt( ( (pointDetectorWindow[0] - CHIPREGIONS_CHIP_CENTER_X.float) * (
-        pointDetectorWindow[0] - CHIPREGIONS_CHIP_CENTER_X.float)) + ( (
-        pointDetectorWindow[1] - CHIPREGIONS_CHIP_CENTER_Y.float) * (
-        pointDetectorWindow[1] - CHIPREGIONS_CHIP_CENTER_Y.float))).mm
-    silver = (r_xy <= CHIPREGIONS_SILVER_RADIUS_MAX.mm) and not gold
-    bronze = not gold and not silver and (r_xy <= CHIPREGIONS_BRONZE_RADIUS_MAX)
+    gold = ( (pointDetectorWindow[0] >= GoldXMin.float) and (
+        pointDetectorWindow[0] <= GoldXMax.float) and (
+        pointDetectorWindow[1] >= GoldYMin.float) and (
+        pointDetectorWindow[1] <= GoldYMax.float))
+    r_xy = sqrt( ( (pointDetectorWindow[0] - ChipCenterX.float) * (
+        pointDetectorWindow[0] - ChipCenterX.float)) + ( (
+        pointDetectorWindow[1] - ChipCenterY.float) * (
+        pointDetectorWindow[1] - ChipCenterY.float))).mm
+    silver = (r_xy <= SilverRadius.mm) and not gold
+    bronze = not gold and not silver and (r_xy <= BronzeRadius)
     withinWindow = r_xy < detectorSetup.detectorWindowAperture / 2
-    detector = ( (pointDetectorWindow[0] >= CHIPREGIONS_CHIP_X_MIN.float) and (
-        pointDetectorWindow[0] <= CHIPREGIONS_CHIP_X_MAX.float) and (
-        pointDetectorWindow[1] >= CHIPREGIONS_CHIP_Y_MIN.float) and (
-        pointDetectorWindow[1] <= CHIPREGIONS_CHIP_Y_MAX.float))
+    detector = ( (pointDetectorWindow[0] >= ChipXMin.float) and (
+        pointDetectorWindow[0] <= ChipXMax.float) and (
+        pointDetectorWindow[1] >= ChipYMin.float) and (
+        pointDetectorWindow[1] <= ChipYMax.float))
   #if (energyAx < 0.3.keV) or (energyAx > 1.9.keV and energyAx < 2.1.keV):
     #echo energyAx, " ", weight #(transWindow), " tel: ", reflect, " det: ", 1.0 - transDet
   ## finally set the `passed` field to indicate this axion went all the way
@@ -2009,7 +2009,7 @@ proc generateResultPlots(axions: seq[Axion],
     geompoint(size = some(0.5), alpha = some(0.1)) +
     ggtitle("X and Y") +
     ggsave(&"../out/xy_{windowYear}.pdf")]#
-  let dfRadFilter = dfRadSig.filter(f{`x` < (CHIPREGIONS_CHIP_CENTER_X.float + 0.05)}).filter(f{`x` > (CHIPREGIONS_CHIP_CENTER_X.float - 0.05)})
+  let dfRadFilter = dfRadSig.filter(f{`x` < (ChipCenterX.float + 0.05)}).filter(f{`x` > (ChipCenterX.float - 0.05)})
   echo dfRadFilter
   ggplot(dfRadFilter, aes("y", fill = factor("Sigma"), weight = "Transmission probability")) +
     geom_histogram(binWidth = 0.001) +
@@ -2054,7 +2054,7 @@ proc generateResultPlots(axions: seq[Axion],
 
   let dfFluxE2 = seqsToDf({ "Axion energy [keV]": energiesAx.mapIt(it.float),
                             "Flux after experiment": weights })
-  dfFluxE2.write_csv(&"axion_gae_1e13_gagamma_{g_aγ.float}_flux_after_exp_N_{numberOfPointsSun}.csv")
+  dfFluxE2.write_csv(&"axion_gae_1e13_gagamma_{g_aγ.float}_flux_after_exp_N_{NumberOfPointsSun}.csv")
   ggplot(dfFluxE2, aes("Axion energy [keV]", weight = "Flux after experiment")) +
     geom_histogram(binWidth = 0.001, lineWidth= some(1.2)) +
     ylab("The flux after the experiment") +
@@ -2080,12 +2080,12 @@ proc generateResultPlots(axions: seq[Axion],
   ## compared to the overall amount and then the data in one pixel compared to the maximal amount of data in any pixel ##
   var
     beginX = 0.0 #- distanceCBAxisXRTAxis * 0.01
-    endX = CHIPREGIONS_CHIP_X_MAX.float  #- distanceCBAxisXRTAxis * 0.01
+    endX = ChipXMax.float  #- distanceCBAxisXRTAxis * 0.01
     beginY = 0.0 #- distanceCBAxisXRTAxis * 0.01
-    endY = CHIPREGIONS_CHIP_Y_MAX.float  #- distanceCBAxisXRTAxis * 0.01
+    endY = ChipYMax.float  #- distanceCBAxisXRTAxis * 0.01
   var heatmaptable1 = prepareHeatmap(3000, 3000, beginX, endX, beginY, endY,
       pointdataX, pointdataY, weights,
-      numberOfPointsSun.float) #colour scale is now the number of points in one pixel divided by the the number of all events
+      NumberOfPointsSun.float) #colour scale is now the number of points in one pixel divided by the the number of all events
   var heatmaptable2 = prepareHeatmap(256, 256, beginX, endX, beginY, endY,
       pointdataX, pointdataY, weights, 1.0)
   var heatmaptable3 = prepareHeatmap(3000, 3000, beginX, endX, beginY, endY,
@@ -2198,13 +2198,13 @@ proc calculateFluxFractions(setup: ExperimentSetupKind,
     var ps = newSeq[float]()
 
     for i in 0 ..< 100_000:
-      let pos = getRandomPointFromSolarModel(centerSun, radiusSun, emratesRadiusCumSum)
+      let pos = getRandomPointFromSolarModel(centerSun, RadiusSun, emratesRadiusCumSum)
       let r = (pos - centerSun).length()
       let energyAx = getRandomEnergyFromSolarModel(
-        pos, centerSun, radiusSun, energies, emrates, emRateCDFs, "energy"
+        pos, centerSun, RadiusSun, energies, emrates, emRateCDFs, "energy"
       )
       let em = getRandomEnergyFromSolarModel(
-        pos, centerSun, radiusSun, energies, emrates, emRateCDFs, "emissionRate"
+        pos, centerSun, RadiusSun, energies, emrates, emRateCDFs, "emissionRate"
       )
       ts.add arccos(pos[2] / r)
       ps.add arctan(pos[1] / pos[0])
@@ -2229,13 +2229,13 @@ proc calculateFluxFractions(setup: ExperimentSetupKind,
   ## In the following we will go over a number of points in the sun, whose location and
   ## energy will be biased by the emission rate and whose track will be through the CAST
   ## experimental setup from 2018 at VT3
-  var axions = newSeq[Axion](numberOfPointsSun)
+  var axions = newSeq[Axion](NumberOfPointsSun)
   var axBuf = cast[ptr UncheckedArray[Axion]](axions[0].addr)
   echo "start"
   #echo emRatesRadiusSum.len
   echo emRates.len
   init(Weave)
-  traceAxionWrapper(axBuf, numberOfPointsSun,
+  traceAxionWrapper(axBuf, NumberOfPointsSun,
                     centerVecs,
                     expSetup,
                     detectorSetup,

--- a/src/raytracer2018.nim
+++ b/src/raytracer2018.nim
@@ -1410,8 +1410,8 @@ proc traceAxion(res: var Axion,
     pointExitCBZylKart, pointMirror1, beta, "angle")
     angle2 = getVectoraAfterMirror(pointAfterMirror1, pointMirror1,
         pointMirror2, beta3, "angle")
-    alpha1 = angle1[1].round(2)
-    alpha2 = angle2[1].round(2)
+    alpha1 = angle1[1]
+    alpha2 = angle2[1]
   #echo (angle1[1].degToRad) , " ", (r1.float - (expSetup.allR1[h-1] + expSetup.allThickness[h-1]).float) / (expSetup.lMirror.float - pointMirror1[2]) #radToDeg(arcsin(r1.float - (expSetup.allR1[h-1] + expSetup.allThickness[h-1]).float) / (expSetup.lMirror.float - pointMirror1[2]))
 
   # getting rid of the X-rays that hit the shell below

--- a/src/raytracer2018.nim
+++ b/src/raytracer2018.nim
@@ -422,14 +422,14 @@ proc lineIntersectsCylinderOnce(point_1: Vec3, point_2: Vec3, centerBegin: Vec3,
   ## and then only once, because else the axions would have just flown through ##
   ##
   ## TODO: can this *please* be merged with the proc below somehow?
-  var 
+  var
     alpha_x = arcsin((centerEnd[0] - centerBegin[0]) / abs(centerBegin[2] - centerEnd[2]))
     alpha_y = arcsin((centerEnd[1] - centerBegin[1]) / abs(centerBegin[2] - centerEnd[2]))
     p_1 = point_1
     p_2 = point_2
     offset_x = 0.0
     offset_y = 0.0
-  
+
   if abs(centerEnd[0]) <= abs(centerBegin[0]):
     offset_x = centerEnd[0]
   else: offset_x = centerBegin[0]
@@ -467,7 +467,7 @@ proc lineIntersectsCylinderOnce(point_1: Vec3, point_2: Vec3, centerBegin: Vec3,
                         (intersect_1[2] < centerEnd[2])
     intersect_2_valid = (intersect_2[2] > centerBegin[2]) and
                         (intersect_2[2] < centerEnd[2])
-  
+
   if ( (intersect_1_valid and intersect_2_valid) or (not intersect_1_valid and
       not intersect_2_valid)):
     return false
@@ -483,7 +483,7 @@ proc getIntersectLineIntersectsCylinderOnce(
   centerBegin: Vec3, centerEnd: Vec3, radius: MilliMeter
      ): Vec3 =
 
-  var 
+  var
     alpha_x = arcsin((centerEnd[0] - centerBegin[0]) / abs(centerBegin[2] - centerEnd[2]))
     alpha_y = arcsin((centerEnd[1] - centerBegin[1]) / abs(centerBegin[2] - centerEnd[2]))
     p_1 = point_1
@@ -567,13 +567,13 @@ proc findPosXRT*(pointXRT: Vec3, pointCB: Vec3,
     sMaxHigh = sMax
     pointMirror = vec3(0.0)
   let direc = pointXRT - pointCB
-  var sValue = ((-direc[1] * point[0].mm * lMirror - direc[0] * point[1].mm * lMirror + direc[2].mm * r1.mm * sec(angle) - 
-                direc[2].mm * r2 * sec(angle)).float - sqrt(pow((-direc[2].mm * r1.mm + direc[2].mm * r2 + 
-                direc[1] * point[0].mm * lMirror * cos(angle) + direc[0] * point[1].mm * lMirror * cos(angle)).float, 2.0) - 
-                4.0 * direc[0] * direc[1] * lMirror.float * cos(angle) * (distMirr * r1.mm - point[2].mm * r1.mm - 
-                distMirr * r2 + point[2].mm * r2 + point[0].mm * point[1].mm * lMirror.float * cos(angle) + 
+  var sValue = ((-direc[1] * point[0].mm * lMirror - direc[0] * point[1].mm * lMirror + direc[2].mm * r1.mm * sec(angle) -
+                direc[2].mm * r2 * sec(angle)).float - sqrt(pow((-direc[2].mm * r1.mm + direc[2].mm * r2 +
+                direc[1] * point[0].mm * lMirror * cos(angle) + direc[0] * point[1].mm * lMirror * cos(angle)).float, 2.0) -
+                4.0 * direc[0] * direc[1] * lMirror.float * cos(angle) * (distMirr * r1.mm - point[2].mm * r1.mm -
+                distMirr * r2 + point[2].mm * r2 + point[0].mm * point[1].mm * lMirror.float * cos(angle) +
                 lMirror * r1.mm * cos(angle)).float) * sec(angle))/(2.0 * direc[0] * direc[1] * lMirror.float)
-  
+
   template calcVal(s: MilliMeter): untyped =
     ## Point + scalar * unit vector essentially. Hence no `mm` for direction.
     ## TODO: this should be handled differently...
@@ -643,13 +643,13 @@ proc getPointDetectorWindow(pointMirror2: Vec3, pointAfterMirror2: Vec3,
                            pointMirror2[2] * sin(pipeRad)) - dCBXray.float
   pointMirror2Turned[1] = pointMirror2[1]
   pointMirror2Turned[2] = (pointMirror2[2] * cos(pipeRad) -
-                           pointMirror2[0] * sin(pipeRad)) 
+                           pointMirror2[0] * sin(pipeRad))
   var pointAfterMirror2Turned = vec3(0.0)
   pointAfterMirror2Turned[0] = (pointAfterMirror2[0] * cos(pipeRad) +
                                 pointAfterMirror2[2] * sin(pipeRad)) - dCBXray.float
   pointAfterMirror2Turned[1] = pointAfterMirror2[1]
   pointAfterMirror2Turned[2] = (pointAfterMirror2[2] * cos(pipeRad) -
-                                pointAfterMirror2[0] * sin(pipeRad)) 
+                                pointAfterMirror2[0] * sin(pipeRad))
   let vectorAfterMirror2 = pointAfterMirror2Turned - pointMirror2Turned
   ## Then the distance from the middle of the telescope to the detector can be calculated with the focal length
   ## Then n can be calculated as hown many times the vector has to be applied to arrive at the detector
@@ -1144,7 +1144,7 @@ proc traceAxion(res: var Axion,
     #pointExitCBMagneticField = getRandomPointOnDisk(centerSpot, (radiusSpot).mm) # for more statistics with hole through optics
     if not lineIntersectsCircle(pointInSun, pointExitCBMagneticField, centerVecs.centerCollimator, expSetup.radiusXraySource):
 
-      
+
       return
     var xraysThroughHole = PI * radiusSpot * radiusSpot /
       (4.0 * PI * (- centerVecs.centerXraySource[2] + centerVecs.centerExitPipeVT3XRT[2]).mm *
@@ -1166,7 +1166,7 @@ proc traceAxion(res: var Axion,
   res.emratesPre = 1.0 #* energyAx.float * energyAx.float * (pointInSunInSun[0].float * pointInSunInSun[0].float + pointInSunInSun[1].float * pointInSunInSun[1].float + pointInSunInSun[2].float * pointInSunInSun[2].float) / 6.9e11 / 6.9e11
   res.energiesPre = energyAx
   if (not intersectsEntranceCB):
-    
+
     intersectsCB = lineIntersectsCylinderOnce(pointInSun,
         pointExitCBMagneticField, centerVecs.centerEntranceCB,
         centerVecs.centerExitCB, expSetup.radiusCB)
@@ -1191,7 +1191,7 @@ proc traceAxion(res: var Axion,
   let pathCB = (pointExitCBMagneticField - intersect).length.mm
   var pointExitCB = vec3(0.0)
   #[if (not lineIntersectsCircle(pointInSun, pointExitCBMagneticField,
-      centerVecs.centerExitCB, expSetup.radiusCB)): 
+      centerVecs.centerExitCB, expSetup.radiusCB)):
         echo "start"
         echo "exit magnet", pointExitCBMagneticField
         return]#
@@ -1220,7 +1220,7 @@ proc traceAxion(res: var Axion,
       pointExitPipeCBVT3 - pointExitCB)
 
   var vectorBeforeXRT = pointExitPipeVT3XRT - pointExitCB
-  
+
   #echo centerVecs.centerCollimator, " ", pointExitPipeVT3XRT
   ###################from the CB (coldbore(pipe in Magnet)) to the XRT (XrayTelescope)#######################
   var vectorXRT = vectorBeforeXRT
@@ -1240,12 +1240,12 @@ proc traceAxion(res: var Axion,
   pointExitCB[2] = pointExitCB[2] * cos(expSetup.telescope_turned_y.to(Radian)) + pointExitCB[1] * sin(expSetup.telescope_turned_y.to(Radian))
 
   var factor = (0.0 - pointExitCB[2]) / vectorXRT[2]
-  
+
   #echo "before ", pointExitCB, " ", vectorBeforeXRT, " after ", pointExitCBXRT, " ", vectorXRT
 
 
   var pointEntranceXRT = pointExitCB + factor * vectorXRT
-  
+
   vectorBeforeXRT = vectorXRT
   ## Coordinate transform from cartesian to polar at the XRT entrance
   var
@@ -1260,9 +1260,9 @@ proc traceAxion(res: var Axion,
   vectorEntranceXRTCircular[0] = radius1.float
   vectorEntranceXRTCircular[1] = phi_radius #in rad
   vectorEntranceXRTCircular[2] = alpha #in rad
-  
+
   ### 3D spider structure 1st draft ###
-  
+
   var factorSpider = (-85.0 - pointExitCB[2]) / vectorXRT[2]
   var pointEntrancSpider = pointExitCB + factorSpider * vectorXRT
   let
@@ -1300,7 +1300,7 @@ proc traceAxion(res: var Axion,
       return
     elif vectorEntranceXRTCircular[0] > 64.7:
       for i in 0..16:
-        if ((phi_flat >= (-1.25 + 22.5 * i.float) and phi_flat <= (1.25 + 22.5 * i.float))) or 
+        if ((phi_flat >= (-1.25 + 22.5 * i.float) and phi_flat <= (1.25 + 22.5 * i.float))) or
            ((phi_flatSpider >= (-1.25 + 22.5 * i.float) and phi_flatSpider <= (1.25 + 22.5 * i.float))): #spider strips (actually wider for innermost but doesnn't matter because it doesnt reach the window anyways)
           return
     #TODO: inner spider structure that doesnt matter
@@ -1397,7 +1397,7 @@ proc traceAxion(res: var Axion,
     pointMirror2 = findPosXRT(pointAfterMirror1, pointMirror1, r4, r5, beta3,
                               expSetup.lMirror, distanceMirrors, 0.01.mm, 0.0.mm, 2.5.mm)
   #echo r1, " ", expSetup.allR1[h-1], " ", r2, " ", expSetup.allR1[h-1] - expSetup.lMirror * sin(expSetup.allAngles[h-1].to(Radian))
-  
+
 
   if pointMirror2[0] == 0.0 and pointMirror2[1] == 0.0 and pointMirror2[2] ==
       0.0: return ## with more uncertainty, 10% of the 0.1% we loose here can be recovered, but it gets more uncertain
@@ -1414,7 +1414,7 @@ proc traceAxion(res: var Axion,
     alpha2 = angle2[1].round(2)
   #echo (angle1[1].degToRad) , " ", (r1.float - (expSetup.allR1[h-1] + expSetup.allThickness[h-1]).float) / (expSetup.lMirror.float - pointMirror1[2]) #radToDeg(arcsin(r1.float - (expSetup.allR1[h-1] + expSetup.allThickness[h-1]).float) / (expSetup.lMirror.float - pointMirror1[2]))
 
-  # getting rid of the X-rays that hit the shell below 
+  # getting rid of the X-rays that hit the shell below
   if testXray == false and tan(angle1[1].degToRad) > (r1.float - (expSetup.allR1[h-1] + expSetup.allThickness[h-1]).float) / (expSetup.lMirror.float - pointMirror1[2]):
     #if not (pointMirror1[2] +  0.0001 >  pointLowerMirror[2] and pointMirror1[2] -  0.0001 <  pointLowerMirror[2]):
     echo "hit Nickel"
@@ -1448,7 +1448,7 @@ proc traceAxion(res: var Axion,
     (distDet + detectorSetup.depthDet),
     expSetup.allXsep[8], d, expSetup.pipes_turned
   )
-  
+
 
   ## TODO: what is this? 2^{x - y} ??
   res.deviationDet = sqrt(
@@ -2017,7 +2017,7 @@ proc generateResultPlots(axions: seq[Axion],
     ylab("flux") +
     ggtitle("Simulated X-ray signal distribution along the y-axis") +
     ggsave(&"../out/y_{windowYear}.pdf")
-  
+
 
   #[let dfRadSigW = seqsToDf({"Radial component [mm]": pointdataRSig,
                         "Transmission probability": weightsSig,
@@ -2072,7 +2072,7 @@ proc generateResultPlots(axions: seq[Axion],
 
 
   ]#
-  
+
 
 
   echo "all plots done, now to heatmap!"

--- a/src/raytracer2018.nim
+++ b/src/raytracer2018.nim
@@ -138,7 +138,7 @@ type
   ConfigFlags = enum
     cfIgnoreDetWindow,   ## use to ignore the detector window absorbtion
     cfIgnoreGasAbs,      ## use to ignore the gas transmission
-    cfIgnoreGoldReflect, ## use to ignore gold reflectivity (use 1.0)
+    cfIgnoreReflection,  ## use to ignore reflectivity (use 1.0) of telescope layer coating
     cfIgnoreConvProb,    ## use to ignore axion conversion probability
     cfXrayTest
 
@@ -2254,7 +2254,7 @@ proc calculateFluxFractions(setup: ExperimentSetupKind,
   generateResultPlots(axions, detectorSetup.windowYear)
 
 proc main(ignoreDetWindow = false, ignoreGasAbs = false,
-          ignoreConvProb = false, ignoreGoldReflect = false, xrayTest = false) =
+          ignoreConvProb = false, ignoreReflection = false, xrayTest = false) =
   # check if the `config.toml` file exists, otherwise recreate from the default
   if not fileExists("config.toml"):
     let cdata = readFile("config_default.toml")
@@ -2264,10 +2264,10 @@ proc main(ignoreDetWindow = false, ignoreGasAbs = false,
   coldboreBlockedLength = 0.0
 
   var flags: set[ConfigFlags]
-  if ignoreDetWindow:   flags.incl cfIgnoreDetWindow
-  if ignoreGasAbs:      flags.incl cfIgnoreGasAbs
-  if ignoreConvProb:    flags.incl cfIgnoreConvProb
-  if ignoreGoldReflect: flags.incl cfIgnoreGoldReflect
+  if ignoreDetWindow:  flags.incl cfIgnoreDetWindow
+  if ignoreGasAbs:     flags.incl cfIgnoreGasAbs
+  if ignoreConvProb:   flags.incl cfIgnoreConvProb
+  if ignoreReflection: flags.incl cfIgnoreReflection
   if xrayTest: flags.incl cfXrayTest
   echo "Flags: ", flags
 

--- a/tools/compute_llnl_layer_reflectivities.py
+++ b/tools/compute_llnl_layer_reflectivities.py
@@ -1,0 +1,63 @@
+# Needs the DarpanX python library
+# https://github.com/biswajitmb/DarpanX
+
+# Based on the DarpanX example 3
+
+# Computes the reflectivities of the different kinds of layers of the
+# LLNL telescope. See the DTU PhD thesis to understand where these
+# parameters here come from
+
+import darpanx as drp
+import numpy as np
+
+m1 = drp.Multilayer(MultilayerType="DepthGraded",
+                    SubstrateMaterial="SiO2",
+                    D_min = 11.5,
+                    D_max = 22.5,
+                    Gamma = 0.45,
+                    C = 1.0,
+                    LayerMaterial=["Pt", "C"],
+                    Repetition=2,
+                    SigmaValues=[1.0])
+
+m2 = drp.Multilayer(MultilayerType="DepthGraded",
+                    SubstrateMaterial="SiO2",
+                    D_min = 7.0,
+                    D_max = 19.0,
+                    Gamma = 0.45,
+                    C = 1.0,
+                    LayerMaterial=["Pt", "C"],
+                    Repetition=3,
+                    SigmaValues=[1.0])
+
+m3 = drp.Multilayer(MultilayerType="DepthGraded",
+                    SubstrateMaterial="SiO2",
+                    D_min = 5.5,
+                    D_max = 16.0,
+                    Gamma = 0.4,
+                    C = 1.0,
+                    LayerMaterial=["Pt", "C"],
+                    Repetition=4,
+                    SigmaValues=[1.0])
+
+m4 = drp.Multilayer(MultilayerType="DepthGraded",
+                    SubstrateMaterial="SiO2",
+                    D_min = 5.0,
+                    D_max = 14.0,
+                    Gamma = 0.4,
+                    C = 1.0,
+                    LayerMaterial=["Pt", "C"],
+                    Repetition=5,
+                    SigmaValues=[1.0])
+
+
+ms = [m1, m2, m3, m4]
+
+Energy = np.linspace(0.01, 15.0, 1000) # scan in a range wider than we use in the raytracer
+Theta = [0.5] # the angle under which we check
+
+from pathlib import Path
+Path("plots").mkdir(exist_ok = True)
+for i, m in enumerate(ms):
+    m.get_optical_func(Theta = Theta, Energy = Energy)
+    m.plot(ylog = "no", Comp = ["Ra"], OutFile = "plots/Pt_SiC_" + str(i), Struc = 'yes')

--- a/tools/compute_llnl_layer_reflectivity.nim
+++ b/tools/compute_llnl_layer_reflectivity.nim
@@ -1,0 +1,67 @@
+## Needs the DarpanX python library
+## https://github.com/biswajitmb/DarpanX
+#
+## Based on the DarpanX example 3
+#
+## Computes the reflectivities of the different kinds of layers of the
+## LLNL telescope. See the DTU PhD thesis to understand where these
+## parameters here come from
+##
+## Nim version using nimpy
+
+import std / os
+import nimpy, ggplotnim
+
+let np = pyImport("numpy")
+let drp = pyImport("darpanx")
+
+let m1 = drp.Multilayer(MultilayerType="DepthGraded",
+                        SubstrateMaterial="SiO2",
+                        D_min = 11.5,
+                        D_max = 22.5,
+                        Gamma = 0.45,
+                        C = 1.0,
+                        LayerMaterial=["Pt", "C"],
+                        Repetition=2,
+                        SigmaValues=[1.0])
+
+let m2 = drp.Multilayer(MultilayerType="DepthGraded",
+                        SubstrateMaterial="SiO2",
+                        D_min = 7.0,
+                        D_max = 19.0,
+                        Gamma = 0.45,
+                        C = 1.0,
+                        LayerMaterial=["Pt", "C"],
+                        Repetition=3,
+                        SigmaValues=[1.0])
+
+let m3 = drp.Multilayer(MultilayerType="DepthGraded",
+                        SubstrateMaterial="SiO2",
+                        D_min = 5.5,
+                        D_max = 16.0,
+                        Gamma = 0.4,
+                        C = 1.0,
+                        LayerMaterial=["Pt", "C"],
+                        Repetition=4,
+                        SigmaValues=[1.0])
+
+let m4 = drp.Multilayer(MultilayerType="DepthGraded",
+                        SubstrateMaterial="SiO2",
+                        D_min = 5.0,
+                        D_max = 14.0,
+                        Gamma = 0.4,
+                        C = 1.0,
+                        LayerMaterial=["Pt", "C"],
+                        Repetition=5,
+                        SigmaValues=[1.0])
+
+
+let ms = [m1, m2, m3, m4]
+
+let Energy = np.linspace(0.01, 15.0, 1000) # scan in a range wider than we use in the raytracer
+let ϑ = [0.5] # the angle under which we check
+
+createDir("plots")
+for i, m in ms:
+  discard m.get_optical_func(Theta = ϑ, Energy = Energy)
+  discard m.plot(ylog = "no", Comp = ["Ra"], OutFile = "plots/Pt_SiC_" & $i, Struc = "yes")

--- a/tools/llnl_layer_reflectivity.nim
+++ b/tools/llnl_layer_reflectivity.nim
@@ -1,0 +1,79 @@
+import nimpy, ggplotnim, nimhdf5
+import scinim / numpyarrays
+
+#let np = pyImport("numpy")
+let drp = pyImport("darpanx")
+
+let m1 = drp.Multilayer(MultilayerType="DepthGraded",
+                        SubstrateMaterial="SiO2",
+                        D_min = 11.5,
+                        D_max = 22.5,
+                        Gamma = 0.45,
+                        C = 1.0,
+                        LayerMaterial=["Pt", "C"],
+                        Repetition=2,
+                        SigmaValues=[1.0])
+
+let m2 = drp.Multilayer(MultilayerType="DepthGraded",
+                        SubstrateMaterial="SiO2",
+                        D_min = 7.0,
+                        D_max = 19.0,
+                        Gamma = 0.45,
+                        C = 1.0,
+                        LayerMaterial=["Pt", "C"],
+                        Repetition=3,
+                        SigmaValues=[1.0])
+
+let m3 = drp.Multilayer(MultilayerType="DepthGraded",
+                        SubstrateMaterial="SiO2",
+                        D_min = 5.5,
+                        D_max = 16.0,
+                        Gamma = 0.4,
+                        C = 1.0,
+                        LayerMaterial=["Pt", "C"],
+                        Repetition=4,
+                        SigmaValues=[1.0])
+
+let m4 = drp.Multilayer(MultilayerType="DepthGraded",
+                        SubstrateMaterial="SiO2",
+                        D_min = 5.0,
+                        D_max = 14.0,
+                        Gamma = 0.4,
+                        C = 1.0,
+                        LayerMaterial=["Pt", "C"],
+                        Repetition=5,
+                        SigmaValues=[1.0])
+
+
+let ms = [m1, m2, m3, m4]
+
+let Energy = linspace(0.01, 15.0, 1000) # scan in a range wider than we use in the raytracer
+let ϑs = linspace(0.0, 1.5, 1000) # [0.5] # the angle under which we check
+
+var h5f = H5open("/tmp/data.h5", "rw")
+var eDset = h5f.create_dataset("Energy", (Energy.len, 1), dtype = float64)
+var aDset = h5f.create_dataset("Angles", (ϑs.len, 1), dtype = float64)
+eDset[eDset.all] = Energy
+aDset[aDset.all] = ϑs
+
+let Enp = Energy.toTensor.toNdArray
+for i, m in ms:
+  var df = newDataFrame()
+  var refl = zeros[float]([Energy.len, ϑs.len])
+  var ϑidx = 0
+  for ϑ in ϑs:
+    # compute the reflectivity
+    discard m.get_optical_func(Theta = [ϑ], Energy = Enp)
+    let reflect = toTensor[float64](m.Ra)
+    refl[ϑidx, _] = reflect
+    let dfLoc = seqsToDf({"Energy" : Energy, "Theta" : ϑ, "Ref" : reflect})
+    df.add dfLoc
+    inc ϑidx
+  echo df
+  #df.writeCsv("/tmp/reflectivity_angles.csv")
+  ggplot(df, aes("Energy", "Theta", fill = "Ref")) +
+    geom_raster() +
+    ggtitle("Reflectivity of LLNL layer type " & $i) +
+    ggsave("/tmp/layer" & $i & ".pdf")
+  var rDset = h5f.create_dataset("Reflectivity" & $i, (Energy.len, ϑs.len), dtype = float64)
+  rDset.unsafeWrite(refl.dataArray, refl.size)


### PR DESCRIPTION
Adds the DarpanX tool to generate the multi layer reflectivities and while I was at it, did a long overdue clean up of the `ExperimentSetup` to make it easier to add more things (e.g. different telescopes).

More things can now also changed via the config file.

- [ ] still have to finish implementing the reflectivity changes fully