### PR TITLE
[tools] raise CT error if henke downloader compiled without SSL

### DIFF
--- a/tools/download_henke_files.nim
+++ b/tools/download_henke_files.nim
@@ -3,6 +3,9 @@ import seqmath
 
 import cligen/[osUt,mslice,procpool]
 
+when not defined(ssl):
+  {.error: "This module must be compiled with SSL support. Compile with `-d:ssl` to enable.".}
+
 const henkeUrl = "https://henke.lbl.gov/"
 const materialInterface = "cgi-bin/laymir.pl"
 


### PR DESCRIPTION
I was a dummy and didn't realize my `try / except` would catch the
HttpRequestError for "compiled without SSL support".